### PR TITLE
added additional v2ray symbolic link

### DIFF
--- a/ShadowsocksX-NG/v2ray-plugin/install_v2ray_plugin.sh
+++ b/ShadowsocksX-NG/v2ray-plugin/install_v2ray_plugin.sh
@@ -15,5 +15,6 @@ mkdir -p "$HOME/Library/Application Support/ShadowsocksX-NG/v2ray-plugin_$VERSIO
 cp -f v2ray-plugin "$HOME/Library/Application Support/ShadowsocksX-NG/v2ray-plugin_$VERSION/"
 
 ln -sfh "$HOME/Library/Application Support/ShadowsocksX-NG/v2ray-plugin_$VERSION/v2ray-plugin" "$HOME/Library/Application Support/ShadowsocksX-NG/plugins/v2ray-plugin"
+ln -sfh "$HOME/Library/Application Support/ShadowsocksX-NG/v2ray-plugin_$VERSION/v2ray-plugin" "$HOME/Library/Application Support/ShadowsocksX-NG/plugins/v2ray"
 
 echo "install v2ray-plugin done"


### PR DESCRIPTION
At present it will create `v2ray-plugin` symbolic link but in Android it's `v2ray`. Sometime need to share configuration using QR code that time need to edit it manually. In this change will create additional `v2ray` symbolic link.