### PR TITLE
Feat(QRCode): Enhance 'Scan QR Code From Screen' notifications # #1250

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Build
         run: |
           brew install automake
+          brew install autoconf
+          brew install libtool
           make VERSION="${GITHUB_SHA::7}" debug
           make debug-dmg
           shasum -a 256 build/Debug/ShadowsocksX-NG.dmg > build/Debug/ShadowsocksX-NG.dmg.checksum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Build
         run: |
           brew install automake
+          brew install autoconf
+          brew install libtool
           make VERSION="${GITHUB_REF_NAME}" release
           make release-dmg 
           shasum -a 256 build/Release/ShadowsocksX-NG.dmg > build/Release/ShadowsocksX-NG.dmg.checksum

--- a/ShadowsocksX-NG/Info.plist
+++ b/ShadowsocksX-NG/Info.plist
@@ -49,5 +49,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>SWBApplication</string>
+	<key>NSScreenCaptureUsageDescription</key>
+	<string>ShadowsocksX-NG needs Screen Recording permission to scan QR codes on your screen</string>
 </dict>
 </plist>


### PR DESCRIPTION
Improve the clarity of notifications in the QR code scanning feature:

1. Permission handling:
   - Show notification when screen recording permission is missing
   - Automatically open system settings for permission grant

![feature1](https://github.com/user-attachments/assets/a3f0d775-d50c-4725-85f7-653fc602e1e1)


2. Enhanced scanning status notifications: When no QR code found:
   - Title: "Scanned X displays"
   - Subtitle: "No QR codes found"
   - Body: "Try adjusting the QR code position on your screen"

   When invalid QR codes found:
   - Title: "Found X QR code(s)"
   - Subtitle: "No valid Shadowsocks URLs"
   - Body: "QR codes found are not Shadowsocks configuration"

   When valid QR codes found:
   - Title: "Found X Shadowsocks URL(s)"
   - Subtitle: "Scanned X displays, found X QR codes"
   - Body: "Successfully added X server configuration(s)"

![feature2](https://github.com/user-attachments/assets/0d320e43-7a6c-4dba-8899-02eb2af89847)


